### PR TITLE
22 remove gigsprocessor from batch

### DIFF
--- a/findagig-batch/src/main/java/findagig/batch/domain/factory/GigsFactory.java
+++ b/findagig-batch/src/main/java/findagig/batch/domain/factory/GigsFactory.java
@@ -35,7 +35,9 @@ public class GigsFactory {
 
             gig.setArtist(this.createArtist(artist));
 
-            gig.setVenue(this.createVenue(event.getVenue()));
+            if (event.getVenue() != null) {
+                gig.setVenue(this.createVenue(event.getVenue()));
+            }
             gigs.add(gig);
         });
 
@@ -66,7 +68,7 @@ public class GigsFactory {
      */
     private Venue createVenue(findagig.source.entity.Venue sourceVenue) {
         Venue venue = new Venue();
-        venue.setId(sourceVenue.getId());
+        venue.setId(sourceVenue.getId() != null ? sourceVenue.getId() : 0);
         venue.setDescription("");
         venue.setDisplayName(sourceVenue.getDisplayName());
         //venue.setWebsite(sourceVenue.getWebsite());

--- a/findagig-batch/src/main/java/findagig/batch/job/GigsReader.java
+++ b/findagig-batch/src/main/java/findagig/batch/job/GigsReader.java
@@ -14,8 +14,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static net.logstash.logback.argument.StructuredArguments.keyValue;
 
@@ -33,9 +31,9 @@ public class GigsReader implements ItemReader<Event> {
         //At this point, only events from the below cities will be collected.
         //The HashMap below contains a key/value of City and MetroAreaId
         metroAreas.put("WINNIPEG", 27403);
-        metroAreas.put("TORONTO", 27396);
-        metroAreas.put("VANCOUVER", 27398);
-        metroAreas.put("MUNICH", 28549);
+        //metroAreas.put("TORONTO", 27396);
+        //metroAreas.put("VANCOUVER", 27398);
+        //metroAreas.put("MUNICH", 28549);
     }
 
     @Override
@@ -55,7 +53,7 @@ public class GigsReader implements ItemReader<Event> {
     }
 
 
-    protected List<Event> readEvents() {
+    private List<Event> readEvents() {
         metroAreas.forEach((key, value) -> {
             long time = System.currentTimeMillis();
             List<Event> newList = driver.getUpcomingEventsByMetroAreaId(value);

--- a/findagig-batch/src/main/java/findagig/batch/job/GigsWriter.java
+++ b/findagig-batch/src/main/java/findagig/batch/job/GigsWriter.java
@@ -1,19 +1,25 @@
 package findagig.batch.job;
 
 import findagig.batch.domain.entity.Gig;
+import findagig.source.entity.Event;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.batch.item.ItemWriter;
 
 import java.util.List;
 
-public class GigsWriter implements ItemWriter<List<Gig>> {
+import static net.logstash.logback.argument.StructuredArguments.keyValue;
+
+public class GigsWriter implements ItemWriter<Event> {
+
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Override
-    public void write(List<? extends List<Gig>> list) throws Exception {
-
-        list.stream().forEach(gigs -> {
-            gigs.stream().forEach(gig -> {
-                System.out.println("Gig " + gig);
-            });
+    public void write(List<? extends Event> items) throws Exception {
+        long time = System.currentTimeMillis();
+        items.stream().forEach(item -> {
+            logger.info("Event was written", keyValue("event", "EVENT_WRITE"), keyValue("EVENT_ID", item.getId()), keyValue("EVENT_DISPLAY-NAME", item.getDisplayName()), keyValue("duration", System.currentTimeMillis() - time));
         });
     }
 }

--- a/findagig-batch/src/main/java/findagig/batch/job/JobConfigurator.java
+++ b/findagig-batch/src/main/java/findagig/batch/job/JobConfigurator.java
@@ -33,9 +33,10 @@ public class JobConfigurator {
 
     @Bean
     public Step orderStep1() {
-        return stepBuilderFactory.get("orderStep1").<Event, List<Gig>>chunk(1)
+        return stepBuilderFactory.get("orderStep1").<Event, Event>chunk(1)
+        //return stepBuilderFactory.get("orderStep1").<Event, List<Gig>>chunk(1)
                 .reader(new GigsReader())
-                .processor(new GigsProcessor())
+                //.processor(new GigsProcessor())
                 .writer(new GigsWriter()).build();
     }
 

--- a/findagig-batch/src/test/java/findagig/batch/job/GigsReaderTest.java
+++ b/findagig-batch/src/test/java/findagig/batch/job/GigsReaderTest.java
@@ -10,9 +10,9 @@ import static org.junit.jupiter.api.Assertions.*;
 class GigsReaderTest {
 
     @Test
-    void read() {
+    void read() throws Exception {
         GigsReader reader = new GigsReader();
-        List<Event> allEvents = reader.readEvents();
-        assertTrue(allEvents.size() > 50);
+        Event event = reader.read();
+        assertTrue(event != null);
     }
 }

--- a/findagig-batch/src/test/java/findagig/batch/job/GigsWriterTest.java
+++ b/findagig-batch/src/test/java/findagig/batch/job/GigsWriterTest.java
@@ -1,0 +1,30 @@
+package findagig.batch.job;
+
+import findagig.batch.domain.entity.Gig;
+import findagig.batch.domain.factory.GigsFactory;
+import findagig.source.driver.SongKickDriver;
+import findagig.source.entity.Event;
+import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static net.logstash.logback.argument.StructuredArguments.keyValue;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+
+class GigsWriterTest {
+
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @Test
+    void write() throws Exception {
+        GigsReader reader = new GigsReader();
+        Event event = reader.read();
+        Assert.assertTrue(event != null);
+        Assert.assertTrue(event.getDisplayName().length() > 0);
+    }
+}

--- a/findagig-batch/src/test/java/findagig/batch/job/GigsWriterTest.java
+++ b/findagig-batch/src/test/java/findagig/batch/job/GigsWriterTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static net.logstash.logback.argument.StructuredArguments.keyValue;
@@ -18,13 +19,13 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class GigsWriterTest {
 
-    private Logger logger = LoggerFactory.getLogger(this.getClass());
-
     @Test
     void write() throws Exception {
         GigsReader reader = new GigsReader();
+        GigsWriter writer = new GigsWriter();
         Event event = reader.read();
-        Assert.assertTrue(event != null);
-        Assert.assertTrue(event.getDisplayName().length() > 0);
+        List<Event> list = new ArrayList<>();
+        list.add(event);
+        assertAll(() -> writer.write(list));
     }
 }

--- a/findagig-batch/src/test/java/findagig/source/driver/SongkickDriverTest.java
+++ b/findagig-batch/src/test/java/findagig/source/driver/SongkickDriverTest.java
@@ -1,16 +1,22 @@
 package findagig.source.driver;
 
 import findagig.batch.domain.entity.Gig;
+import findagig.batch.domain.factory.GigsFactory;
 import findagig.source.entity.Event;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.LocalDate;
 import java.util.List;
 
+import static net.logstash.logback.argument.StructuredArguments.keyValue;
 import static org.junit.Assert.assertTrue;
 
 class SongkickDriverTest {
+
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Test
     void getEventsByLocationFromDate() {
@@ -32,6 +38,7 @@ class SongkickDriverTest {
     void getUpcomingEventsByMetroAreaId() {
         SongKickDriver driver = new SongKickDriver();
         List<Event> winnipegEvents = driver.getUpcomingEventsByMetroAreaId(27403);
+        logger.info("@Test: Get Events by MetroAreaId", keyValue("event", "EVENT_TEST"));
         assertTrue(winnipegEvents.get(0).getVenue().getMetroArea().getDisplayName().equalsIgnoreCase("Winnipeg"));
     }
 


### PR DESCRIPTION
GigsProcessor has been removed from the batch process, meaning that GigsWriter gets Event objects straightly from GigsReader.